### PR TITLE
Sas exomine turtlebuster

### DIFF
--- a/scripts/exomine.js
+++ b/scripts/exomine.js
@@ -22,7 +22,6 @@ export const exomine = () => {
             ${govsHTML()}
             </section>
             <section class="choices__facilities options">
-            
             ${facilitiesHTML()}  
             </section>
         </article>

--- a/scripts/exomine.js
+++ b/scripts/exomine.js
@@ -18,10 +18,10 @@ export const exomine = () => {
 
         <article class="choices">
             <section class="choices__governors options">
-                ${()}
+                
             </section>
             <section class="choices__facilities options">
-                ${()}
+            
             </section>
         </article>
 
@@ -31,7 +31,7 @@ export const exomine = () => {
 
         <article class="customOrders">
             <h2>Colony Minerals</h2>
-            ${()}
+        
         </article>
     `
 }

--- a/scripts/facilities.js
+++ b/scripts/facilities.js
@@ -7,22 +7,23 @@ const facilities = getFacilities()
 //created var to hold a value which will hold the facilityID value once the facility change event takes place 
 let facilityId = 0
 /////////// let var of GovId = 0 to hold gonernorId value once change takes place
-let GovId = 0
+//let GovId = 0
 //////////create change event listener to hear when governor is changed that will set the global scoped
 ////////// GovId var to the parseInt(event.target.value) 
-document.addEventListener(
-    "change",
-    (event) => {
-        if (event.target.id === "governor") {
-            //sets the globally scoped GovID var value to the governorId value  
-            GovId = (parseInt(event.target.value))
-           // document.dispatchEvent(new CustomEvent("stateChanged"))
-        }
-    })
-    const testGovId = () => {
-        if(GovId != 0)
-        return GovId
-    }
+
+// document.addEventListener(
+//     "change",
+//     (event) => {
+//         if (event.target.id === "governor") {
+//             //sets the globally scoped GovID var value to the governorId value  
+//             GovId = (parseInt(event.target.value))
+//            // document.dispatchEvent(new CustomEvent("stateChanged"))
+//         }
+//     })
+//     const testGovId = () => {
+//         if(GovId != 0)
+//         return GovId
+//     }
 
 // function that will give selectable options as dropdown for facility with facility.name 
 ////////////////need to: to happen only after governor is selected once gov.js is merged
@@ -32,9 +33,9 @@ export const facilitiesHTML = () => {
     let html = ""
     html += "<h2>Choose a Facility:</h2>"
     ////////// if GovId === 0 { add header and dropdown tab to string}
-    if (GovId === 0) {
-        html += '<select id="facility"><option value="0">Choose a Facility...</option>'
-    } else {
+    // if (GovId === 0) {
+    //     html += '<select id="facility"><option value="0">Choose a Facility...</option>'
+    // } else {
         //html += '<option value="0">Choose a Facility...</option>'
         ///////// also add the interpolated string choices below 
         for (const facility of facilities) {
@@ -44,7 +45,7 @@ export const facilitiesHTML = () => {
         html += "</select>"
     } 
     return html
-}
+//}
 
 // listens for facility to change and sets that facilityId in transient state Obj in database
 // also sets the var facilityId to the value of the facility clicked

--- a/scripts/facilities.js
+++ b/scripts/facilities.js
@@ -6,46 +6,35 @@ const facilities = getFacilities()
 
 //created var to hold a value which will hold the facilityID value once the facility change event takes place 
 let facilityId = 0
-/////////// let var of GovId = 0 to hold gonernorId value once change takes place
-//let GovId = 0
-//////////create change event listener to hear when governor is changed that will set the global scoped
-////////// GovId var to the parseInt(event.target.value) 
+//created var to hold a value which will hold the govId value once the governor change event takes place
+let govId = 0
 
-// document.addEventListener(
-//     "change",
-//     (event) => {
-//         if (event.target.id === "governor") {
-//             //sets the globally scoped GovID var value to the governorId value  
-//             GovId = (parseInt(event.target.value))
-//            // document.dispatchEvent(new CustomEvent("stateChanged"))
-//         }
-//     })
-//     const testGovId = () => {
-//         if(GovId != 0)
-//         return GovId
-//     }
+//listens to when governor is selected
+document.addEventListener(
+    "change",
+    (event) => {
+        if (event.target.id === "governor") {
+            //sets globally scoped var govId value to selected governor
+            govId = (parseInt(event.target.value))
+            document.dispatchEvent(new CustomEvent("stateChanged"))
+        }
+    })
 
 // function that will give selectable options as dropdown for facility with facility.name 
-////////////////need to: to happen only after governor is selected once gov.js is merged
 export const facilitiesHTML = () => {
-    /////////// emtpy string 
-    testGovId()
-    let html = ""
-    html += "<h2>Choose a Facility:</h2>"
-    ////////// if GovId === 0 { add header and dropdown tab to string}
-    // if (GovId === 0) {
-    //     html += '<select id="facility"><option value="0">Choose a Facility...</option>'
-    // } else {
-        //html += '<option value="0">Choose a Facility...</option>'
-        ///////// also add the interpolated string choices below 
+    let html = "<h2>Choose a Facility</h2>"
+    html += '<select id="facility">'
+    html += '<option value="0">Choose a Facility...</option>'
+    // makes facility options only populate happen governor is selected
+    if (govId > 0) {
         for (const facility of facilities) {
-            html += `<select>
-            <option value="${facility.id}">${facility.name}</option>`
+            html += `<option value="${facility.id}">${facility.name}</option>`
         }
-        html += "</select>"
-    } 
+
+    }
+    html += "</select>"
     return html
-//}
+}
 
 // listens for facility to change and sets that facilityId in transient state Obj in database
 // also sets the var facilityId to the value of the facility clicked

--- a/scripts/facilities.js
+++ b/scripts/facilities.js
@@ -1,23 +1,48 @@
 import { getFacilitiesMinerals, getMinerals, getFacilities, setFacility } from "./database.js";
 
 // set functions to variables
-
 const minerals = getMinerals()
 const facilities = getFacilities()
 
 //created var to hold a value which will hold the facilityID value once the facility change event takes place 
 let facilityId = 0
+/////////// let var of GovId = 0 to hold gonernorId value once change takes place
+let GovId = 0
+//////////create change event listener to hear when governor is changed that will set the global scoped
+////////// GovId var to the parseInt(event.target.value) 
+document.addEventListener(
+    "change",
+    (event) => {
+        if (event.target.id === "governor") {
+            //sets the globally scoped GovID var value to the governorId value  
+            GovId = (parseInt(event.target.value))
+           // document.dispatchEvent(new CustomEvent("stateChanged"))
+        }
+    })
+    const testGovId = () => {
+        if(GovId != 0)
+        return GovId
+    }
 
 // function that will give selectable options as dropdown for facility with facility.name 
 ////////////////need to: to happen only after governor is selected once gov.js is merged
 export const facilitiesHTML = () => {
-    let html = "<h2>Choose a Facility</h2>"
-    html += '<select id="facility">'
-    html += '<option value="0">Choose a Facility...</option>'
-    for (const facility of facilities) {
-        html += `<option value="${facility.id}">${facility.name}</option>`
-    }
-    html += "</select>"
+    /////////// emtpy string 
+    testGovId()
+    let html = ""
+    html += "<h2>Choose a Facility:</h2>"
+    ////////// if GovId === 0 { add header and dropdown tab to string}
+    if (GovId === 0) {
+        html += '<select id="facility"><option value="0">Choose a Facility...</option>'
+    } else {
+        //html += '<option value="0">Choose a Facility...</option>'
+        ///////// also add the interpolated string choices below 
+        for (const facility of facilities) {
+            html += `<select>
+            <option value="${facility.id}">${facility.name}</option>`
+        }
+        html += "</select>"
+    } 
     return html
 }
 


### PR DESCRIPTION
# Description
This merge will make the facility drop down tab  only populate once a governor is chosen
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)
Makes facility options only available after governor is selected.
## Type of change
changes functionality to facility options
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A
1. serve in dom 
2. select choose facility tab(no options will be given)
3. choose a governor
4. select choose facility tab(all active facilities will populate as options) 

# Checklist:

- [y ] My code follows the style guidelines of this project
- [ y] I have performed a self-review of my own code
- [ y] I have commented my code, particularly in hard-to-understand areas
- [ y] My changes generate no new warnings
